### PR TITLE
docs: Add Slack badge and link to channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ While we started with just node modules (as defined in `package.json` files) and
 
 Take a look at [our public repository](https://github.com/backyourstack/backyourstack), [create or pick up issues](https://github.com/backyourstack/backyourstack/issues) and help us make open source more sustainable for everyone! 🙌
 
+We also have [a Slack community channel](https://opencollective.slack.com/archives/CMFGW1CTD), part of the Open Collective slack. Come join us!
+
 ## Contributing ideas
 
 If you want to help and are not sure where to start, we have some ideas!

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://travis-ci.org/backyourstack/backyourstack.svg?branch=master)](https://travis-ci.org/backyourstack/backyourstack)
 [![Dependency Status](https://david-dm.org/backyourstack/backyourstack/status.svg)](https://david-dm.org/backyourstack/backyourstack)
+[![Slack Status](https://slack.opencollective.com/badge.svg)](https://opencollective.slack.com/archives/CMFGW1CTD)
 
 Discover the open source projects your organization is using that need financial support.
 


### PR DESCRIPTION
I do not know if this is the best way to do it, as it makes it look like all of the Slack is dedicated to BackYourStack in the Slack badge, but I think that having the link in general is a good move.