### PR TITLE
grammar: Remove unnecessary auxiliary verb

### DIFF
--- a/src/components/Upload.js
+++ b/src/components/Upload.js
@@ -154,7 +154,7 @@ export default class Upload extends React.Component {
           >
             <p>
               There was an error while uploading your files. At the moment, we
-              do support {supportedFilesAsComponent}. Please try again. If the
+              support {supportedFilesAsComponent}. Please try again. If the
               problem persists, please contact us.
             </p>
           </div>

--- a/src/components/__tests__/__snapshots__/Upload.js.snap
+++ b/src/components/__tests__/__snapshots__/Upload.js.snap
@@ -57,7 +57,7 @@ exports[`Upload should render 1`] = `
     <p
       className="jsx-1203312298"
     >
-      There was an error while uploading your files. At the moment, we support
+      There was an error while uploading your files. At the moment, we support 
       <em>
         composer.json
       </em>
@@ -144,7 +144,7 @@ exports[`Upload should render with feedbackPosition 1`] = `
     <p
       className="jsx-1203312298"
     >
-      There was an error while uploading your files. At the moment, we support
+      There was an error while uploading your files. At the moment, we support 
       <em>
         composer.json
       </em>
@@ -232,7 +232,7 @@ exports[`Upload should render with style 1`] = `
     <p
       className="jsx-1203312298"
     >
-      There was an error while uploading your files. At the moment, we support
+      There was an error while uploading your files. At the moment, we support 
       <em>
         composer.json
       </em>

--- a/src/components/__tests__/__snapshots__/Upload.js.snap
+++ b/src/components/__tests__/__snapshots__/Upload.js.snap
@@ -57,7 +57,7 @@ exports[`Upload should render 1`] = `
     <p
       className="jsx-1203312298"
     >
-      There was an error while uploading your files. At the moment, we do support 
+      There was an error while uploading your files. At the moment, we support
       <em>
         composer.json
       </em>
@@ -144,7 +144,7 @@ exports[`Upload should render with feedbackPosition 1`] = `
     <p
       className="jsx-1203312298"
     >
-      There was an error while uploading your files. At the moment, we do support 
+      There was an error while uploading your files. At the moment, we support
       <em>
         composer.json
       </em>
@@ -232,7 +232,7 @@ exports[`Upload should render with style 1`] = `
     <p
       className="jsx-1203312298"
     >
-      There was an error while uploading your files. At the moment, we do support 
+      There was an error while uploading your files. At the moment, we support
       <em>
         composer.json
       </em>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -263,7 +263,7 @@ export default class Index extends Component {
               </div>
               <p className="boxDescription">
                 If you want to analyze private or local repositories simply
-                upload dependency files. At the moment, we do support{' '}
+                upload dependency files. At the moment, we support{' '}
                 {supportedFilesAsComponent}.
               </p>
               <div className="uploadContainer">


### PR DESCRIPTION
"support" is sufficient; "do support" sounds awkward.