### PR TITLE
fix: Point out users need to sign in

### DIFF
--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -39,7 +39,7 @@ export default class SearchForm extends React.Component {
     if (!profile) {
       this.setState({
         error:
-          '✗ There is no GitHub organization or user with this identifier.',
+          '✗ Either you are not signed in, or this is not a valid GitHub identifier.',
         ok: null,
       });
     } else {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -248,9 +248,9 @@ export default class Index extends Component {
                 <h3>Use a GitHub profile</h3>
               </div>
               <p className="boxDescription">
-                Enter your GitHub profile id and we&apos;ll scan all public
-                repositories under it. You may Sign In with GitHub if you want
-                to give us access to private repositories too.
+                Enter any GitHub organization or identifier, and we'll find its
+                dependencies! You must be signed in with GitHub (see the NavBar)
+                for this to work, or for us to access your private repositories.
               </p>
               <SearchForm orgs={loggedInUserOrgs} />
             </div>


### PR DESCRIPTION
Right now, this form will not work if you are not authenticated with GitHub. This messaging makes that a bit more clear.